### PR TITLE
Use prop-types library instead of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "eslint": "2.2.0",
     "eslint-config-airbnb": "6.0.2",
     "eslint-plugin-react": "4.1.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class HttpsRedirect extends React.Component {
 
@@ -27,7 +28,7 @@ class HttpsRedirect extends React.Component {
 }
 
 HttpsRedirect.propTypes = {
-  children: React.PropTypes.node,
+  children: PropTypes.node,
 };
 
 export default HttpsRedirect;


### PR DESCRIPTION
This addresses the following warning in console logs

```
Accessing PropTypes via the main React package is deprecated
```

Reference: https://facebook.github.io/react/warnings/dont-call-proptypes.html