### PR TITLE
Remove wrapping div

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class HttpsRedirect extends React.Component {
-
   isLocalHost(hostname) {
-    return !!(hostname === 'localhost' ||
-              hostname === '[::1]' ||
-              hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/));
+    return !!(
+      hostname === 'localhost' ||
+      hostname === '[::1]' ||
+      hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
+    );
   }
 
   render() {
@@ -16,19 +17,18 @@ class HttpsRedirect extends React.Component {
       window.location.protocol === 'http:' &&
       !this.isLocalHost(window.location.hostname)
     ) {
-      window.location.href = window.location.href.replace(/^http(?!s)/, 'https');
+      window.location.href = window.location.href.replace(
+        /^http(?!s)/,
+        'https'
+      );
     }
 
-    return (
-      <div>
-        { this.props.children }
-      </div>
-    );
+    return this.props.children;
   }
 }
 
 HttpsRedirect.propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.node
 };
 
 export default HttpsRedirect;


### PR DESCRIPTION
The component now returns `this.props.children` directly, instead of wrapping them inside a `div`.

This will help for example when we need the body's content to have `height: 100%;`, without having to write somewhere in the code `#root > div { height: 100%}`.